### PR TITLE
Remove pinning option from Task Meow

### DIFF
--- a/server/bot-service.js
+++ b/server/bot-service.js
@@ -337,26 +337,6 @@ class AuthBot extends builder.UniversalBot {
                 }
               }
             }
-          },
-          {
-            type: "Action.Submit",
-            title: "Pin as Tab",
-            data: {
-              msteams: {
-                type: "invoke",
-                overflow: "true",
-                value: {
-                  type: "tab/tabInfoAction",
-                  tabInfo: {
-                    contentUrl: contentUrl,
-                    websiteUrl: websiteUrl,
-                    name: "Tasks",
-                    entityId: "entityId",
-                    pinTab: true
-                  }
-                }
-              }
-            }
           }
         ]
       },


### PR DESCRIPTION
Clean up Task Meow by removing the pinning option from the adaptive card