### PR TITLE
Removed window.opener check before calling notifySuccess auth response.

### DIFF
--- a/server/views/end-v2.pug
+++ b/server/views/end-v2.pug
@@ -30,9 +30,8 @@ html
       app
         .handleRedirectPromise()
         .then((authResponse) => {
-          window.opener &&
             microsoftTeams.authentication.notifySuccess(authResponse);
         })
         .catch((error) => {
-          window.opener && microsoftTeams.authentication.notifyFailure(error);
+          microsoftTeams.authentication.notifyFailure(error);
         });

--- a/server/views/end.pug
+++ b/server/views/end.pug
@@ -23,12 +23,9 @@ html
       if (authContext.isCallback(window.location.hash)) {
         authContext.handleWindowCallback(window.location.hash);
 
-        // Only call notifySuccess or notifyFailure if this page is in the authentication popup
-        if (window.opener) {
-          if (authContext.getCachedUser()) {
+        if (authContext.getCachedUser()) {
             microsoftTeams.authentication.notifySuccess();
           } else {
             microsoftTeams.authentication.notifyFailure(authContext.getLoginError());
           }
-        }
       }


### PR DESCRIPTION
Found that in the below code `server/views/end-v2.pug` `window.opener` is undefined which leads to notifySuccess Not being called and the popup on iOS does not dismiss.

` window.opener && microsoftTeams.authentication.notifySuccess(authResponse);`

Above check fails on iOS as the auth popup is not initiated by the main window but it is a native view controller with an independent web view instance. `window.opener` returns `undefined` here. 


 