### PR TITLE
Fix redirect to profile after successful login

### DIFF
--- a/src/services/msal.naa.auth.service.js
+++ b/src/services/msal.naa.auth.service.js
@@ -68,16 +68,17 @@ class MsalNAAAuthService {
         extraScopesToConsent: ["User.Read"],
         loginHint: context.loginHint,
       };
-
+      let activeAccount;
       await this.appNext
         .acquireTokenPopup(silentRequest)
         .then((authResponse) => {
           this.appNext.setActiveAccount(authResponse.account);
-          return authResponse.account;
+          activeAccount = authResponse.account;
         })
         .catch(() => {
           throw new Error("login failed");
         });
+        return Promise.resolve(activeAccount);
     });
   }
 


### PR DESCRIPTION
Fix promise resolve in login function to allow the state to be set correctly on the login page after a successful login. 