### PR TITLE
Add bot widget

### DIFF
--- a/mcp-widget/vite.config.js
+++ b/mcp-widget/vite.config.js
@@ -1,5 +1,4 @@
 import { defineConfig } from "vite";
-import { viteSingleFile } from "vite-plugin-singlefile";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -7,12 +6,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   root: __dirname,
-  plugins: [viteSingleFile()],
   build: {
     outDir: path.resolve(__dirname, "../server/build"),
     emptyOutDir: false,
     rollupOptions: {
       input: path.resolve(__dirname, "embed.html"),
+      output: {
+        entryFileNames: "assets/embed.js",
+      },
     },
   },
 });

--- a/server/bot-service.js
+++ b/server/bot-service.js
@@ -7,10 +7,16 @@ import {
 
 import { AzureOpenAI } from "openai";
 import { App, ExpressAdapter } from "@microsoft/teams.apps";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import groupService from "./group-service.js";
 import taskService from "./task-service.js";
 import userService from "./user-service.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 if (
   !process.env.APPSETTING_OPENAI_KEY &&
@@ -309,6 +315,42 @@ async function initBot(expressApp) {
   // Error handling
   teamsApp.event("error", async ({ error }) => {
     console.error(`\n [onError] unhandled error:`, error);
+  });
+
+  // Return an MCP UI widget
+  teamsApp.message("/widget", async ({ send }) => {
+    // Read the real widget HTML and resolve script paths to absolute URLs
+    const baseUri = process.env.APPSETTING_AAD_BaseUri || "https://localhost";
+    const domain = new URL(baseUri).hostname;
+    const htmlPath = path.join(__dirname, "build", "embed.html");
+    let widgetHtml = await fs.readFile(htmlPath, "utf-8");
+    widgetHtml = widgetHtml.replace(
+      /src="\/assets\//g,
+      `src="${baseUri}/assets/`
+    );
+
+    const widgetPayload = {
+      type: "widget/mcp-ui",
+      name: "My Tasks",
+      description:
+        "Interactive task management widget showing your current tasks.",
+      domain,
+      widgetHtml,
+    };
+
+    const widgetMarkdown = [
+      "Here are your tasks:",
+      "",
+      "```html-widget",
+      JSON.stringify(widgetPayload),
+      "```",
+    ].join("\n");
+
+    await send({
+      type: "message",
+      text: widgetMarkdown,
+      textFormat: "extendedmarkdown",
+    });
   });
 
   // Reset conversation state

--- a/server/bot-service.js
+++ b/server/bot-service.js
@@ -335,7 +335,7 @@ async function initBot(expressApp) {
       description:
         "Interactive task management widget showing your current tasks.",
       domain,
-      widgetHtml,
+      html: widgetHtml,
     };
 
     const widgetMarkdown = [

--- a/server/mcp-server.js
+++ b/server/mcp-server.js
@@ -23,7 +23,10 @@ const ASSETS_DIR = path.resolve(__dirname, "build");
 
 async function readWidgetHtml() {
   const htmlPath = path.join(ASSETS_DIR, "embed.html");
-  return await fs.readFile(htmlPath, "utf-8");
+  const baseUri = process.env.APPSETTING_AAD_BaseUri || "https://localhost";
+  let html = await fs.readFile(htmlPath, "utf-8");
+  html = html.replace(/src="\/assets\//g, `src="${baseUri}/assets/`);
+  return html;
 }
 
 // Resource URIs


### PR DESCRIPTION
This pull request introduces support for serving an interactive MCP UI widget as part of the bot's responses and ensures that asset URLs in the widget HTML are correctly resolved to absolute URLs. The changes affect both the build configuration for the widget and the server logic for serving the widget HTML.

**Widget serving and asset path resolution:**

* Added a `/widget` message handler in `server/bot-service.js` that reads the built `embed.html`, rewrites asset paths to use the correct base URI, and sends the widget as an HTML widget payload in an extended markdown message.
* Updated the `readWidgetHtml` function in `server/mcp-server.js` to perform the same asset path rewriting, ensuring consistent asset resolution when serving the widget HTML directly.

**Build configuration updates:**

* Modified `mcp-widget/vite.config.js` to remove the `vite-plugin-singlefile` plugin and configure the output so that the main entry JavaScript is always named `assets/embed.js`, improving asset management and path predictability.

**Server-side utility improvements:**

* Added imports for `fs`, `path`, and `fileURLToPath` from Node.js in `server/bot-service.js` to support reading files and resolving paths in an ES module context.